### PR TITLE
Add fallback URL handling and robust fetching for feed generation

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,32 +1,36 @@
 [
-{
-  "name": "GALA-Global",
-  "url": "https://www.gala-global.org/news/",
-  "baseUrl": "https://www.gala-global.org",
-  "articleSelector": ".articles .article",
-  "titleSelector": ".c-article-list-full-width__wrapper",
-  "linkSelector": ".c-article-list-full-width__wrapper",
-  "descriptionSelector": ".c-article-list__description",
-  "dateSelector": ".c-article-list__date"
-},
-{
-  "name": "XTM Blog",
-  "url": "https://xtm.cloud/blog/",
-  "baseUrl": "https://xtm.cloud",
-  "articleSelector": ".post-card.cpt-listing-single",
-  "titleSelector": ".post-card-title",
-  "linkSelector": "a.post-card-link-wrapper",
-  "descriptionSelector": ".post-card-caption",
-  "dateSelector": ""
-},
   {
-  "name": "Mutilingual",
-  "url": "https://multilingual.com/news/feed",
-  "baseUrl": "https://multilingual.com/",
-  "articleSelector": "item",
-  "titleSelector": "title",
-  "linkSelector": "link",
-  "descriptionSelector": "description",
-  "dateSelector": "pubDate"
-}
+    "name": "GALA-Global",
+    "url": "https://www.gala-global.org/news/",
+    "baseUrl": "https://www.gala-global.org",
+    "articleSelector": ".articles .article",
+    "titleSelector": ".c-article-list-full-width__wrapper",
+    "linkSelector": ".c-article-list-full-width__wrapper",
+    "descriptionSelector": ".c-article-list__description",
+    "dateSelector": ".c-article-list__date"
+  },
+  {
+    "name": "XTM Blog",
+    "url": "https://xtm.cloud/blog/",
+    "baseUrl": "https://xtm.cloud",
+    "articleSelector": ".post-card.cpt-listing-single",
+    "titleSelector": ".post-card-title",
+    "linkSelector": "a.post-card-link-wrapper",
+    "descriptionSelector": ".post-card-caption",
+    "dateSelector": ""
+  },
+  {
+    "name": "Mutilingual",
+    "url": "https://multilingual.com/news/feed",
+    "baseUrl": "https://multilingual.com/",
+    "articleSelector": "item",
+    "titleSelector": "title",
+    "linkSelector": "link",
+    "descriptionSelector": "description",
+    "dateSelector": "pubDate",
+    "fallbackUrls": [
+      "https://multilingual.com/news/",
+      "https://multilingual.com/feed/"
+    ]
+  }
 ]

--- a/generate.js
+++ b/generate.js
@@ -97,8 +97,8 @@ function extractArticlesFromAnchors($, pageUrl) {
 }
 
 function getFallbackArticles($, site) {
-  const fromJsonLd = extractArticlesFromJsonLd($, site.url);
-  const fromAnchors = extractArticlesFromAnchors($, site.url);
+  const fromJsonLd = extractArticlesFromJsonLd($, site.baseUrl || site.url);
+  const fromAnchors = extractArticlesFromAnchors($, site.baseUrl || site.url);
 
   const deduped = new Map();
 
@@ -111,6 +111,48 @@ function getFallbackArticles($, site) {
   return [...deduped.values()].slice(0, MAX_ITEMS);
 }
 
+
+
+async function fetchSiteContent(site) {
+  const candidateUrls = [site.url, ...(site.fallbackUrls || [])].filter(Boolean);
+  let lastError = null;
+
+  for (let index = 0; index < candidateUrls.length; index += 1) {
+    const candidateUrl = candidateUrls[index];
+    try {
+      const response = await axios.get(candidateUrl, {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+          Accept:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,text/xml;q=0.9,*/*;q=0.8",
+          "Accept-Language": "en-US,en;q=0.9",
+          Referer: site.baseUrl || candidateUrl,
+        },
+        timeout: 15000,
+      });
+
+      return {
+        data: response.data,
+        sourceUrl: candidateUrl,
+      };
+    } catch (err) {
+      lastError = err;
+      const hasMoreCandidates = index < candidateUrls.length - 1;
+      if (hasMoreCandidates) {
+        console.warn(
+          `Request failed for ${site.name} at ${candidateUrl} (${err.message}); trying fallback URL.`
+        );
+      }
+    }
+  }
+
+  if (lastError) {
+    lastError.message = `${lastError.message} (tried URLs: ${candidateUrls.join(", ")})`;
+  }
+
+  throw lastError || new Error("Unable to fetch any configured URL.");
+}
 function parseArticleDate(rawDate) {
   if (!rawDate) return null;
 
@@ -171,24 +213,25 @@ function parseArticleDate(rawDate) {
       fs.mkdirSync(rssDir);
     }
 
-    await Promise.all(
+    const results = await Promise.all(
       config.map(async (site) => {
         try {
           console.log(`Generating feed for ${site.name}`);
 
-          const { data } = await axios.get(site.url, {
-            headers: {
-              "User-Agent": "Mozilla/5.0",
-            },
-            timeout: 15000,
-          });
+          const { data, sourceUrl } = await fetchSiteContent(site);
+
+          if (sourceUrl !== site.url) {
+            console.warn(
+              `Using fallback URL for ${site.name}: ${sourceUrl}`
+            );
+          }
 
           const $ = cheerio.load(data);
 
           const feed = new RSS({
             title: `${site.name} Feed`,
             description: `RSS feed generated for ${site.name}`,
-            site_url: site.url,
+            site_url: sourceUrl,
             feed_url: `https://aparasion.github.io/rss-generator/rss/${site.name}.xml`,
             language: "en",
             pubDate: new Date(),
@@ -265,11 +308,25 @@ function parseArticleDate(rawDate) {
           fs.writeFileSync(outputPath, feed.xml({ indent: true }));
 
           console.log(`Finished ${site.name} (${count} items)`);
+          return { site: site.name, status: "fulfilled", count };
         } catch (err) {
           console.error(`Failed for ${site.name}: ${err.message}`);
+          return { site: site.name, status: "rejected", reason: err.message };
         }
       })
     );
+
+    const failures = results.filter((result) => result.status === "rejected");
+
+    if (failures.length > 0) {
+      console.error(
+        `RSS generation completed with ${failures.length} failure(s): ${failures
+          .map((failure) => failure.site)
+          .join(", ")}.`
+      );
+      process.exitCode = 1;
+      return;
+    }
 
     console.log("All feeds generated successfully.");
   } catch (err) {


### PR DESCRIPTION
### Motivation

- Improve reliability of feed generation by trying alternative URLs when a site's primary `url` fails and by recording which URL was used in the feed metadata.

### Description

- Add `fallbackUrls` support in `config.json` for sites (added to the Multilingual entry) and normalize formatting of the config file.
- Introduce `fetchSiteContent(site)` in `generate.js` to attempt the primary `site.url` and any `site.fallbackUrls` in order with improved request headers, timeout, and retry logging, returning the `data` and `sourceUrl` used.
- Use `site.baseUrl || site.url` when extracting fallback articles and set the RSS `site_url` to the actual `sourceUrl` used; emit a warning when a fallback URL is used.
- Convert the main site processing to collect per-site results from `Promise.all`, return structured success/failure info for each site, and set `process.exitCode = 1` when any site failed.

### Testing

- Ran the generator with `node generate.js` and confirmed XML files were produced in the `rss/` directory for configured sites when primary URLs were reachable, with exit code 0.
- Simulated an unreachable primary URL and confirmed the code logged a fallback attempt, used the fallback URL, produced the feed, and printed a warning indicating the fallback `sourceUrl` used.
- Verified that when a site ultimately failed after trying all candidates the run reports the failed site(s) and exits with a non-zero exit code (process exit code set to 1).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab07c19b5c832b92f4475490af10ea)