### PR TITLE
Handle missing output files on 304 responses

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,10 +29,10 @@
   {
   "name": "lokalise-blog",
   "url": "https://lokalise.com/blog/",
-  "articleSelector": ".group/blog-card .relative .flex .flex-col .w-full .items-start .text-left .BlogCard-module__PrsQuW__blog-card .blog-card",
-  "titleSelector": "h2.BlogCard-module__PrsQuW__title",
-  "linkSelector": "a.blog-card",
-  "descriptionSelector": "p.lok-text-body-regular-medium .text-brand-black .text-ellipsis .line-clamp-4 .break-word .mb-4",
+  "articleSelector": "[class*='BlogCard-module']",
+  "titleSelector": "h2",
+  "linkSelector": "a[href*='/blog/']",
+  "descriptionSelector": "p.lok-text-body-regular-medium",
   "dateSelector": ".lok-text-body-small"
 },
 {

--- a/generate.js
+++ b/generate.js
@@ -456,18 +456,28 @@ async function processSite(site, httpCache, seenCache) {
   // Per-site seen map — mutated in place and persisted by the caller.
   if (site.contentFilter && !seenCache[site.name]) seenCache[site.name] = {};
 
-  const fetchResult = await fetchPage(site.url, httpCache);
+  let fetchResult = await fetchPage(site.url, httpCache);
 
   if (fetchResult.notModified) {
-    console.log(`  ${site.name}: page unchanged (304); skipping re-parse.`);
-    return {
-      name: site.name,
-      url: site.url,
-      feedUrl: `${FEED_BASE_URL}/rss/${site.name}.xml`,
-      status: "not_modified",
-      items: null,
-      durationMs: Date.now() - t0,
-    };
+    const outputPath = path.join(rssDir, `${site.name}.xml`);
+    if (fs.existsSync(outputPath)) {
+      console.log(`  ${site.name}: page unchanged (304); skipping re-parse.`);
+      return {
+        name: site.name,
+        url: site.url,
+        feedUrl: `${FEED_BASE_URL}/rss/${site.name}.xml`,
+        status: "not_modified",
+        items: null,
+        durationMs: Date.now() - t0,
+      };
+    }
+    // Output file is missing despite a 304 — clear conditional headers and re-fetch
+    console.log(`  ${site.name}: output file missing despite 304; forcing unconditional re-fetch.`);
+    if (httpCache[site.url]) {
+      delete httpCache[site.url].etag;
+      delete httpCache[site.url].lastModified;
+    }
+    fetchResult = await fetchPage(site.url, httpCache);
   }
 
   const $ = cheerio.load(fetchResult.html);

--- a/rss/cache.json
+++ b/rss/cache.json
@@ -5,8 +5,5 @@
     "lastModified": "Sun, 08 Mar 2026 23:27:54 GMT"
   },
   "https://phrase.com/blog/": {},
-  "https://lokalise.com/blog/": {
-    "etag": "W/\"28664cc9c24f3900bdada66252f048e4\"",
-    "lastModified": "Fri, 06 Mar 2026 14:23:12 GMT"
-  }
+  "https://lokalise.com/blog/": {}
 }


### PR DESCRIPTION
## Summary
This PR improves the robustness of the feed generation process by handling a race condition where a 304 Not Modified response is received but the corresponding output file is missing. It also simplifies CSS selectors for the Lokalise blog to be more resilient to DOM changes.

## Key Changes
- **Cache validation logic**: Modified `processSite()` to check if the output RSS file exists before returning early on a 304 response. If the file is missing despite a 304, the conditional headers (ETag and Last-Modified) are cleared and an unconditional re-fetch is performed.
- **Lokalise blog selectors**: Simplified CSS selectors to use more generic patterns:
  - Article selector: Changed from a long chain of classes to `[class*='BlogCard-module']`
  - Title selector: Changed from `h2.BlogCard-module__PrsQuW__title` to `h2`
  - Link selector: Changed from `a.blog-card` to `a[href*='/blog/']`
  - Description selector: Simplified to `p.lok-text-body-regular-medium`
- **Cache reset**: Cleared cached headers for the Lokalise blog URL to allow fresh fetching with the updated selectors

## Implementation Details
- The 304 handling now uses a two-tier approach: first check if output exists, then conditionally re-fetch if needed
- Selector changes use attribute matching and class substring matching for better resilience to CSS class name changes
- The cache entry for Lokalise blog was reset to ensure the new selectors are applied on the next run

https://claude.ai/code/session_012ySxxd1ArWWN4MnLaYTqTH