### PR TITLE
Simplify Crowdin blog CSS selectors

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,11 +38,11 @@
   {
   "name": "crowdin-blog",
   "url": "https://crowdin.com/blog",
-  "articleSelector": ".group .h-full .lg:order-4",
-  "titleSelector": "h3.order-1 .font-heading .font-bold .group-hover:underline .text-lg .leading-normal",
-  "linkSelector": "a.group .h-full lg:col-span-1",
-  "descriptionSelector": "p.order-3 .mt-1 .line-clamp-3 .text-gray-700 .dark:text-gray-300 .px-8",
-  "dateSelector": "datetime .datetime"
+  "articleSelector": ".group",
+  "titleSelector": "h3",
+  "linkSelector": "a",
+  "descriptionSelector": "p",
+  "dateSelector": "time"
 },
 {
   "name": "PRNewswire-L10N",

--- a/rss/cache.json
+++ b/rss/cache.json
@@ -9,8 +9,5 @@
     "etag": "W/\"28664cc9c24f3900bdada66252f048e4\"",
     "lastModified": "Fri, 06 Mar 2026 14:23:12 GMT"
   },
-  "https://crowdin.com/blog": {
-    "etag": "W/\"69a8493d-234ed\"",
-    "lastModified": "Wed, 04 Mar 2026 15:01:17 GMT"
-  }
+  "https://crowdin.com/blog": {}
 }


### PR DESCRIPTION
## Summary
Simplified the CSS selectors for the Crowdin blog feed configuration by removing overly specific class combinations and replacing them with more generic, maintainable selectors.

## Key Changes
- **Article selector**: Changed from `.group .h-full .lg:order-4` to `.group` - removes unnecessary utility class specificity
- **Title selector**: Changed from `h3.order-1 .font-heading .font-bold .group-hover:underline .text-lg .leading-normal` to `h3` - uses semantic HTML element instead of class chain
- **Link selector**: Changed from `a.group .h-full lg:col-span-1` to `a` - simplified to basic anchor tag
- **Description selector**: Changed from `p.order-3 .mt-1 .line-clamp-3 .text-gray-700 .dark:text-gray-300 .px-8` to `p` - uses semantic HTML element
- **Date selector**: Changed from `datetime .datetime` to `time` - uses proper HTML5 semantic element
- **Cache reset**: Cleared cached etag and lastModified values for the Crowdin blog feed to force refresh with new selectors

## Implementation Details
These changes make the selectors more resilient to CSS class changes on the Crowdin blog website. By targeting semantic HTML elements and minimal class selectors, the feed parser will be less likely to break if the site's styling classes are updated. The cache was cleared to ensure the feed is re-fetched and parsed with the new selectors.

https://claude.ai/code/session_01EEsoaHYP1Ea541igKxXBNh