### PR TITLE
Simplify DeepL blog article selector

### DIFF
--- a/config.json
+++ b/config.json
@@ -47,7 +47,7 @@
   {
   "name": "DeepL-blog",
   "url": "https://www.deepl.com/en/blog",
-  "articleSelector": ".bg-redesign-quartz-gray-200 .rounded-redesign-default .relative .flex .cursor-pointer .flex-col .justify-between .overflow-hidden .p-4 .pb-6 .lg:gap-10 .lg:p-5",
+  "articleSelector": ".bg-redesign-quartz-gray-200",
   "titleSelector": "h6",
   "linkSelector": "a",
   "descriptionSelector": "p",


### PR DESCRIPTION
## Summary
Simplified the CSS selector for the DeepL blog article scraper to improve maintainability and reduce brittleness.

## Changes
- Replaced overly specific nested CSS selector with a simpler, more robust selector
  - **Before**: `.bg-redesign-quartz-gray-200 .rounded-redesign-default .relative .flex .cursor-pointer .flex-col .justify-between .overflow-hidden .p-4 .pb-6 .lg:gap-10 .lg:p-5`
  - **After**: `.bg-redesign-quartz-gray-200`

## Details
The original selector was highly specific and fragile, depending on multiple nested class combinations that could easily break with minor CSS refactoring on the target website. The simplified selector targets the container element directly using the primary background color class, which is more stable and easier to maintain. The nested selectors for title, link, and description remain unchanged and will continue to work within the selected article containers.

https://claude.ai/code/session_01RtvNZovjqZ2ysRbTuPMawi