### PR TITLE
fix: target individual article cards and filter links by blog path fo…

### DIFF
--- a/config.json
+++ b/config.json
@@ -47,9 +47,9 @@
   {
   "name": "DeepL-blog",
   "url": "https://www.deepl.com/en/blog",
-  "articleSelector": ".bg-redesign-quartz-gray-200",
+  "articleSelector": ".bg-redesign-quartz-gray-200 .rounded-redesign-default",
   "titleSelector": "h6",
-  "linkSelector": "a",
+  "linkSelector": "a[href*='/en/blog/']",
   "descriptionSelector": "p",
   "dateSelector": "time"
 },


### PR DESCRIPTION
…r DeepL-blog

- articleSelector: .bg-redesign-quartz-gray-200 selects the entire blog listing container (one element), not individual cards. Each article card has .rounded-redesign-default, so use the descendant selector to iterate over individual cards instead of the whole container.

- linkSelector: bare 'a' picks up the first anchor in each card which may point to author profiles, tags, or other non-article pages. Use the attribute selector a[href*='/en/blog/'] to restrict to blog article URLs.