### PR TITLE
fix: handle self-anchor article cards and add linkPathPrefix config o…

### DIFF
--- a/config.json
+++ b/config.json
@@ -50,6 +50,7 @@
   "articleSelector": ".bg-redesign-quartz-gray-200 .rounded-redesign-default",
   "titleSelector": "h6",
   "linkSelector": "a[href*='/en/blog/']",
+  "linkPathPrefix": "/en/blog/",
   "descriptionSelector": "p",
   "dateSelector": "time"
 },

--- a/generate.js
+++ b/generate.js
@@ -293,6 +293,7 @@ function extractArticlesFromAnchors($, site) {
       if (siteOrigin && parsed.origin !== siteOrigin) return;
       if (link === site.url) return;
       if (listingPathname && parsed.pathname === listingPathname) return;
+      if (site.linkPathPrefix && !parsed.pathname.startsWith(site.linkPathPrefix)) return;
     } catch {
       return;
     }
@@ -504,18 +505,29 @@ async function processSite(site, httpCache, seenCache) {
   // ── Primary extraction via configured CSS selectors ──
   const primaryArticles = [];
   $(site.articleSelector).each((_, el) => {
-    const titleRaw = $(el).find(site.titleSelector).text().trim();
-    const linkRaw = ($(el).find(site.linkSelector).attr("href") || "").trim();
+    const $el = $(el);
+    const titleRaw = $el.find(site.titleSelector).text().trim();
+
+    // Support cards where the article element itself is the link (e.g. <a class="card">)
+    let $linkEl = $el.find(site.linkSelector);
+    if (!$linkEl.length && $el.is(site.linkSelector)) $linkEl = $el;
+    const linkRaw = ($linkEl.attr("href") || "").trim();
+
     if (!titleRaw || !linkRaw) return;
 
     const title = stripHtml(titleRaw);
     const fullLink = normalizeUrl(linkRaw, site.url);
     if (!fullLink || addedLinks.has(fullLink)) return;
 
+    if (site.linkPathPrefix) {
+      try { if (!new URL(fullLink).pathname.startsWith(site.linkPathPrefix)) return; }
+      catch { return; }
+    }
+
     const description = truncate(
       stripHtml(
         site.descriptionSelector
-          ? $(el).find(site.descriptionSelector).text().trim()
+          ? $el.find(site.descriptionSelector).text().trim()
           : ""
       ),
       MAX_DESCRIPTION_LENGTH


### PR DESCRIPTION
…ption

Two root causes for non-blog posts appearing in DeepL-blog feed:

1. When an article card is itself an <a> element (entire card is the link), $(el).find('a') returns nothing because browsers forbid nested anchors, so linkRaw was empty, every article was skipped, and the fallback anchor harvester ran instead — picking up all links on the page. Fix: if find(linkSelector) finds nothing, check if the element itself matches linkSelector (el.is(linkSelector)) and use it directly.

2. When the fallback runs, it only filtered by origin and exact listing URL, allowing nav/footer/product links through.

Introduce linkPathPrefix config field: when set, both primary extraction and the fallback anchor harvester reject any link whose pathname does not start with the prefix. Set to '/en/blog/' for DeepL-blog.