### PR TITLE
Remove trailing comma from final config object

### DIFF
--- a/config.json
+++ b/config.json
@@ -93,5 +93,5 @@
   "linkSelector": ".views-field-title a",
   "descriptionSelector": "",
   "dateSelector": ".datetime"
-},
+}
 ]


### PR DESCRIPTION
## Summary
Fixed a JSON syntax error in the configuration file by removing a trailing comma from the final object in the array.

## Key Changes
- Removed trailing comma after the last configuration object in `config.json`
- This fixes invalid JSON syntax that would cause parsing errors

## Details
The configuration file had a trailing comma after the final object in the array, which is not valid JSON. This change ensures the file is properly formatted and can be parsed without errors.

https://claude.ai/code/session_01RdrXsU7NYkJoP9JUEoKijy