### PR TITLE
Add support for per-site custom HTTP headers

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,15 +35,20 @@
     "descriptionSelector": "p.lok-text-body-regular-medium",
     "dateSelector": ".lok-text-body-small"
   },
-   {
+  {
     "name": "multilingual_com",
     "url": "https://multilingual.com/news/",
     "articleSelector": ".td_module_2.td_module_wrap.td-animation-stack",
     "titleSelector": ".entry-title.td-module-title",
     "linkSelector": "a.entry-title.td-module-title",
-    "descriptionSelector": ".td_module_2.td_module_wrap.td-animation-stack.td-excerpt",
-    "dateSelector": ".entry-date.updated.td-module-date"
-    },
+    "descriptionSelector": ".td-excerpt",
+    "dateSelector": ".entry-date.updated.td-module-date",
+    "headers": {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+      "Accept-Language": "en-US,en;q=0.9"
+    }
+  },
   {
     "name": "crowdin-blog",
     "url": "https://crowdin.com/blog",

--- a/generate.js
+++ b/generate.js
@@ -164,12 +164,13 @@ function saveSeenCache(cache) {
  * or { html: string } on success.
  * Throws on permanent failure.
  */
-async function fetchPage(url, httpCache) {
+async function fetchPage(url, httpCache, extraHeaders = {}) {
   const cached = httpCache[url] || {};
   const reqHeaders = {
     "User-Agent": getRandomUserAgent(),
     Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
     "Accept-Language": "en-US,en;q=0.5",
+    ...extraHeaders,
   };
   if (cached.etag) reqHeaders["If-None-Match"] = cached.etag;
   if (cached.lastModified) reqHeaders["If-Modified-Since"] = cached.lastModified;
@@ -504,7 +505,7 @@ async function processRssFeed(site, httpCache, seenCache) {
 
   if (site.contentFilter && !seenCache[site.name]) seenCache[site.name] = {};
 
-  let fetchResult = await fetchPage(site.url, httpCache);
+  let fetchResult = await fetchPage(site.url, httpCache, site.headers);
 
   if (fetchResult.notModified) {
     const outputPath = path.join(rssDir, `${site.name}.xml`);
@@ -524,7 +525,7 @@ async function processRssFeed(site, httpCache, seenCache) {
       delete httpCache[site.url].etag;
       delete httpCache[site.url].lastModified;
     }
-    fetchResult = await fetchPage(site.url, httpCache);
+    fetchResult = await fetchPage(site.url, httpCache, site.headers);
   }
 
   const $ = cheerio.load(fetchResult.html, { xmlMode: true });
@@ -640,7 +641,7 @@ async function processSite(site, httpCache, seenCache) {
   // Per-site seen map — mutated in place and persisted by the caller.
   if (site.contentFilter && !seenCache[site.name]) seenCache[site.name] = {};
 
-  let fetchResult = await fetchPage(site.url, httpCache);
+  let fetchResult = await fetchPage(site.url, httpCache, site.headers);
 
   if (fetchResult.notModified) {
     const outputPath = path.join(rssDir, `${site.name}.xml`);
@@ -661,7 +662,7 @@ async function processSite(site, httpCache, seenCache) {
       delete httpCache[site.url].etag;
       delete httpCache[site.url].lastModified;
     }
-    fetchResult = await fetchPage(site.url, httpCache);
+    fetchResult = await fetchPage(site.url, httpCache, site.headers);
   }
 
   const $ = cheerio.load(fetchResult.html);


### PR DESCRIPTION
## Summary
This PR adds support for configuring custom HTTP headers on a per-site basis, allowing individual news sources to override default headers when fetching content.

## Key Changes
- **config.json**: Added optional `headers` object to the `multilingual_com` site configuration with custom User-Agent, Accept, and Accept-Language headers. Also fixed CSS selector for description (changed from overly specific selector to `.td-excerpt`) and corrected JSON formatting (indentation and trailing comma).

- **generate.js**: 
  - Modified `fetchPage()` function to accept an optional `extraHeaders` parameter that gets merged into the request headers using the spread operator
  - Updated all four `fetchPage()` calls (two in `processRssFeed()` and two in `processSite()`) to pass `site.headers` as the third argument
  - Custom headers take precedence over default headers due to spread operator placement

## Implementation Details
- The `extraHeaders` parameter defaults to an empty object for backward compatibility
- Custom headers are merged after default headers, allowing site-specific headers to override defaults
- The feature is optional—sites without a `headers` property will continue to use only default headers
- This enables handling sites that require specific headers or have stricter anti-bot protections

https://claude.ai/code/session_01A8o89gJd6vAMy5ghz43vZb