### PR TITLE
Support "self" linkSelector to extract href from element

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -692,8 +692,11 @@ async function processSite(site, httpCache, seenCache) {
     const $el = $(el);
     const title = getPrimaryTitle($el, site);
 
-    const $linkEl = $el.find(site.linkSelector);
-    const linkRaw = ($linkEl.attr("href") || "").trim();
+    const linkRaw = (
+      site.linkSelector === "self"
+        ? ($el.attr("href") || "")
+        : ($el.find(site.linkSelector).attr("href") || "")
+    ).trim();
 
     if (!title || !linkRaw) return;
 


### PR DESCRIPTION
## Summary
Modified the link extraction logic in `processSite()` to support a special "self" linkSelector value that extracts the href attribute directly from the current element, rather than searching for a child element.

## Key Changes
- Updated link extraction logic to check if `site.linkSelector === "self"`
- When linkSelector is "self", the href is extracted directly from the current element (`$el.attr("href")`)
- When linkSelector is any other value, the existing behavior is preserved (finding a child element matching the selector)
- Refactored the code to use a ternary operator for cleaner conditional logic

## Implementation Details
This change allows more flexible selector configuration, enabling sites where the link element itself is the target element (rather than containing a child link element). The "self" value is a special case that bypasses the `.find()` call and directly accesses the href attribute of the current element being processed.

https://claude.ai/code/session_01PeKUhqBTSjwMB9grNbs6pb