### PR TITLE
Add Cohere Newsroom language and translation feed

### DIFF
--- a/config.json
+++ b/config.json
@@ -230,6 +230,31 @@
     }
   },
   {
+    "name": "Cohere-Newsroom-L10N",
+    "url": "https://cohere.com/newsroom/articles",
+    "articleSelector": "a[href*='/newsroom/articles/']",
+    "titleSelector": "h2, h3, h4",
+    "linkSelector": "self",
+    "descriptionSelector": "p",
+    "dateSelector": "time",
+    "linkPattern": "/newsroom/articles/",
+    "feedTitle": "Cohere Newsroom — Language & Translation",
+    "feedDescription": "Cohere newsroom articles filtered for language, translation, and linguistics topics",
+    "contentFilter": {
+      "keywords": [
+        "language",
+        "languages",
+        "linguist",
+        "translate",
+        "translation",
+        "translations"
+      ],
+      "minMatches": 1,
+      "checkFullContent": false,
+      "maxScan": 50
+    }
+  },
+  {
     "name": "OpenAI-News-L10N",
     "type": "rss",
     "url": "https://openai.com/news/rss.xml",


### PR DESCRIPTION
## Summary
Added a new feed configuration for the Cohere Newsroom to extract articles focused on language, translation, and linguistics topics.

## Changes
- Added `Cohere-Newsroom-L10N` feed configuration to `config.json`
- Configured selectors to extract articles from https://cohere.com/newsroom/articles/
  - Article links via `a[href*='/newsroom/articles/']`
  - Titles from heading elements (h2, h3, h4)
  - Descriptions from paragraph elements
  - Publication dates from time elements
- Implemented content filtering with keywords: "language", "languages", "linguist", "translate", "translation", "translations"
  - Requires minimum 1 keyword match per article
  - Scans up to 50 characters of content
- Set descriptive feed title and description for language/translation focused content

## Implementation Details
The feed follows the existing configuration pattern with CSS selectors for DOM traversal and a keyword-based content filter to surface only articles relevant to language and translation topics from the Cohere newsroom.

https://claude.ai/code/session_016kNxPsE7WzNeExMmkf5nkP