### PR TITLE
Fix Cohere Newsroom selectors based on actual page HTML

### DIFF
--- a/config.json
+++ b/config.json
@@ -232,12 +232,12 @@
   {
     "name": "Cohere-Newsroom-L10N",
     "url": "https://cohere.com/newsroom/articles",
-    "articleSelector": "a[href*='/newsroom/articles/']",
-    "titleSelector": "h2, h3, h4",
-    "linkSelector": "self",
-    "descriptionSelector": "p",
-    "dateSelector": "time",
-    "linkPattern": "/newsroom/articles/",
+    "articleSelector": "div[class*='grid-cols-5']",
+    "titleSelector": "h2",
+    "linkSelector": "a[href^='/blog/']",
+    "descriptionSelector": "",
+    "dateSelector": "> p",
+    "linkPattern": "/blog/",
     "feedTitle": "Cohere Newsroom — Language & Translation",
     "feedDescription": "Cohere newsroom articles filtered for language, translation, and linguistics topics",
     "contentFilter": {


### PR DESCRIPTION
- articleSelector: div[class*='grid-cols-5'] matches each article row
- titleSelector: h2 (Tailwind class font-body-web2)
- linkSelector: a[href^='/blog/'] (articles link to /blog/, not /newsroom/)
- dateSelector: > p (direct child <p> holds the date, e.g. "May 27, 2026")
- linkPattern updated from /newsroom/articles/ to /blog/
- descriptionSelector cleared (no summary text on the listing page)

https://claude.ai/code/session_016kNxPsE7WzNeExMmkf5nkP