### PR TITLE
Add DATAmundi-Newsroom to news source configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,14 @@
 [
   {
+    "name": "DATAmundi-Newsroom",
+    "url": "https://datamundi.ai/newsroom/",
+    "articleSelector": ".e-loop-item",
+    "titleSelector": ".elementor-widget-theme-post-title h3 a",
+    "linkSelector": ".elementor-widget-theme-post-title h3 a",
+    "descriptionSelector": "",
+    "dateSelector": ""
+  },
+  {
     "name": "GALA-Global",
     "url": "https://www.gala-global.org/news/",
     "articleSelector": ".articles .article",


### PR DESCRIPTION
## Summary
Added a new news source configuration for DATAmundi-Newsroom to the application's news scraper configuration file.

## Changes
- Added DATAmundi-Newsroom as a new news source with the following configuration:
  - Source URL: `https://datamundi.ai/newsroom/`
  - Article selector: `.e-loop-item`
  - Title/Link selector: `.elementor-widget-theme-post-title h3 a`
  - Description and date selectors left empty (to be configured later if needed)

## Details
The new configuration entry is placed at the beginning of the configuration array and follows the same structure as existing news sources. The selectors target Elementor-based page elements commonly used in WordPress sites.

https://claude.ai/code/session_01V8wd4xzfrb3D8YtybbCyee