### PR TITLE
Add TAUS Blog to article scraper configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,11 +2,12 @@
   {
     "name": "TAUS-Blog",
     "url": "https://www.taus.net/resources/blog/",
-    "articleSelector": "article, .post, .blog-post, .entry, [class*='post-item'], [class*='blog-card']",
-    "titleSelector": "h2, h3, .entry-title, .post-title",
-    "linkSelector": "h2 a, h3 a, .entry-title a, .post-title a, a.read-more",
-    "descriptionSelector": ".entry-summary, .post-excerpt, .excerpt, p",
-    "dateSelector": "time, .entry-date, .post-date, .date"
+    "articleSelector": ".article-card",
+    "titleSelector": ".text-xl.font-semibold",
+    "linkSelector": "a[href*='/resources/blog/']:not([href*='/category/'])",
+    "descriptionSelector": ".line-clamp-5",
+    "dateSelector": ".text-xs.text-gray-950",
+    "linkPattern": "/resources/blog/"
   },
   {
     "name": "DATAmundi-Newsroom",

--- a/config.json
+++ b/config.json
@@ -1,5 +1,14 @@
 [
   {
+    "name": "TAUS-Blog",
+    "url": "https://www.taus.net/resources/blog/",
+    "articleSelector": "article, .post, .blog-post, .entry, [class*='post-item'], [class*='blog-card']",
+    "titleSelector": "h2, h3, .entry-title, .post-title",
+    "linkSelector": "h2 a, h3 a, .entry-title a, .post-title a, a.read-more",
+    "descriptionSelector": ".entry-summary, .post-excerpt, .excerpt, p",
+    "dateSelector": "time, .entry-date, .post-date, .date"
+  },
+  {
     "name": "DATAmundi-Newsroom",
     "url": "https://datamundi.ai/newsroom/",
     "articleSelector": ".e-loop-item",


### PR DESCRIPTION
## Summary
Added configuration for scraping articles from the TAUS Blog to the article scraper configuration file.

## Key Changes
- Added new scraper configuration entry for TAUS Blog (https://www.taus.net/resources/blog/)
- Configured CSS selectors for extracting:
  - Article cards (`.article-card`)
  - Article titles (`.text-xl.font-semibold`)
  - Article links (filtered to `/resources/blog/` URLs, excluding category pages)
  - Article descriptions (`.line-clamp-5`)
  - Publication dates (`.text-xs.text-gray-950`)
- Set link pattern filter to `/resources/blog/` to ensure only blog articles are captured

## Implementation Details
The configuration follows the existing pattern used for other news sources in the config file, with appropriate CSS selectors tailored to the TAUS Blog's HTML structure. The link selector specifically excludes category pages to focus on individual article content.

https://claude.ai/code/session_01XGTu5bSyvZecxwcTv8vWx3